### PR TITLE
Issue #19: SEO.ai Phase 1 data foundations (models, migration, repositories, site CRUD)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -17,7 +17,18 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from app.db.base import Base
-from app.models import api_credential, auth_audit_event, business, lead, lead_event, principal
+from app.models import (
+    api_credential,
+    auth_audit_event,
+    business,
+    lead,
+    lead_event,
+    principal,
+    seo_audit_finding,
+    seo_audit_page,
+    seo_audit_run,
+    seo_site,
+)
 
 config = context.config
 

--- a/alembic/versions/0011_seo_phase1_foundations.py
+++ b/alembic/versions/0011_seo_phase1_foundations.py
@@ -1,0 +1,225 @@
+"""add seo phase 1 foundations
+
+Revision ID: 0011_seo_phase1_foundations
+Revises: 0010_auth_audit_events
+Create Date: 2026-03-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0011_seo_phase1_foundations"
+down_revision = "0010_auth_audit_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "seo_sites",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("business_id", sa.String(length=36), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("base_url", sa.String(length=2048), nullable=False),
+        sa.Column("normalized_domain", sa.String(length=255), nullable=False),
+        sa.Column("industry", sa.String(length=128), nullable=True),
+        sa.Column("primary_location", sa.String(length=255), nullable=True),
+        sa.Column("service_areas_json", sa.JSON(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("is_primary", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["business_id"], ["businesses.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_seo_sites_business_id", "seo_sites", ["business_id"], unique=False)
+    op.create_index("ix_seo_sites_normalized_domain", "seo_sites", ["normalized_domain"], unique=False)
+
+    op.create_table(
+        "seo_audit_runs",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("business_id", sa.String(length=36), nullable=False),
+        sa.Column("site_id", sa.String(length=36), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default="queued"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("max_pages", sa.Integer(), nullable=False, server_default="25"),
+        sa.Column("max_depth", sa.Integer(), nullable=False, server_default="2"),
+        sa.Column("pages_discovered", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("pages_crawled", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column("created_by_principal_id", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["business_id"], ["businesses.id"]),
+        sa.ForeignKeyConstraint(["site_id"], ["seo_sites.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_seo_audit_runs_business_id", "seo_audit_runs", ["business_id"], unique=False)
+    op.create_index("ix_seo_audit_runs_site_id", "seo_audit_runs", ["site_id"], unique=False)
+    op.create_index("ix_seo_audit_runs_status", "seo_audit_runs", ["status"], unique=False)
+    op.create_index(
+        "ix_seo_audit_runs_business_site_created_at",
+        "seo_audit_runs",
+        ["business_id", "site_id", "created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "seo_audit_pages",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("business_id", sa.String(length=36), nullable=False),
+        sa.Column("site_id", sa.String(length=36), nullable=False),
+        sa.Column("audit_run_id", sa.String(length=36), nullable=False),
+        sa.Column("url", sa.String(length=2048), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=True),
+        sa.Column("title", sa.String(length=512), nullable=True),
+        sa.Column("meta_description", sa.Text(), nullable=True),
+        sa.Column("canonical_url", sa.String(length=2048), nullable=True),
+        sa.Column("h1_json", sa.JSON(), nullable=True),
+        sa.Column("h2_json", sa.JSON(), nullable=True),
+        sa.Column("word_count", sa.Integer(), nullable=True),
+        sa.Column("internal_link_count", sa.Integer(), nullable=True),
+        sa.Column("image_count", sa.Integer(), nullable=True),
+        sa.Column("missing_alt_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["business_id"], ["businesses.id"]),
+        sa.ForeignKeyConstraint(["site_id"], ["seo_sites.id"]),
+        sa.ForeignKeyConstraint(["audit_run_id"], ["seo_audit_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_seo_audit_pages_business_id", "seo_audit_pages", ["business_id"], unique=False)
+    op.create_index("ix_seo_audit_pages_site_id", "seo_audit_pages", ["site_id"], unique=False)
+    op.create_index("ix_seo_audit_pages_audit_run_id", "seo_audit_pages", ["audit_run_id"], unique=False)
+    op.create_index(
+        "ix_seo_audit_pages_business_run_url",
+        "seo_audit_pages",
+        ["business_id", "audit_run_id", "url"],
+        unique=False,
+    )
+
+    op.create_table(
+        "seo_audit_findings",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("business_id", sa.String(length=36), nullable=False),
+        sa.Column("site_id", sa.String(length=36), nullable=False),
+        sa.Column("audit_run_id", sa.String(length=36), nullable=False),
+        sa.Column("page_id", sa.String(length=36), nullable=True),
+        sa.Column("finding_type", sa.String(length=64), nullable=False),
+        sa.Column("category", sa.String(length=64), nullable=False),
+        sa.Column("severity", sa.String(length=16), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("details", sa.Text(), nullable=True),
+        sa.Column("rule_key", sa.String(length=128), nullable=False),
+        sa.Column("suggested_fix", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["business_id"], ["businesses.id"]),
+        sa.ForeignKeyConstraint(["site_id"], ["seo_sites.id"]),
+        sa.ForeignKeyConstraint(["audit_run_id"], ["seo_audit_runs.id"]),
+        sa.ForeignKeyConstraint(["page_id"], ["seo_audit_pages.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_seo_audit_findings_business_id", "seo_audit_findings", ["business_id"], unique=False)
+    op.create_index("ix_seo_audit_findings_site_id", "seo_audit_findings", ["site_id"], unique=False)
+    op.create_index(
+        "ix_seo_audit_findings_audit_run_id",
+        "seo_audit_findings",
+        ["audit_run_id"],
+        unique=False,
+    )
+    op.create_index("ix_seo_audit_findings_page_id", "seo_audit_findings", ["page_id"], unique=False)
+    op.create_index(
+        "ix_seo_audit_findings_finding_type",
+        "seo_audit_findings",
+        ["finding_type"],
+        unique=False,
+    )
+    op.create_index("ix_seo_audit_findings_category", "seo_audit_findings", ["category"], unique=False)
+    op.create_index("ix_seo_audit_findings_severity", "seo_audit_findings", ["severity"], unique=False)
+    op.create_index("ix_seo_audit_findings_rule_key", "seo_audit_findings", ["rule_key"], unique=False)
+    op.create_index(
+        "ix_seo_audit_findings_business_run_created_at",
+        "seo_audit_findings",
+        ["business_id", "audit_run_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_seo_audit_findings_business_run_created_at", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_rule_key", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_severity", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_category", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_finding_type", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_page_id", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_audit_run_id", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_site_id", table_name="seo_audit_findings")
+    op.drop_index("ix_seo_audit_findings_business_id", table_name="seo_audit_findings")
+    op.drop_table("seo_audit_findings")
+
+    op.drop_index("ix_seo_audit_pages_business_run_url", table_name="seo_audit_pages")
+    op.drop_index("ix_seo_audit_pages_audit_run_id", table_name="seo_audit_pages")
+    op.drop_index("ix_seo_audit_pages_site_id", table_name="seo_audit_pages")
+    op.drop_index("ix_seo_audit_pages_business_id", table_name="seo_audit_pages")
+    op.drop_table("seo_audit_pages")
+
+    op.drop_index("ix_seo_audit_runs_business_site_created_at", table_name="seo_audit_runs")
+    op.drop_index("ix_seo_audit_runs_status", table_name="seo_audit_runs")
+    op.drop_index("ix_seo_audit_runs_site_id", table_name="seo_audit_runs")
+    op.drop_index("ix_seo_audit_runs_business_id", table_name="seo_audit_runs")
+    op.drop_table("seo_audit_runs")
+
+    op.drop_index("ix_seo_sites_normalized_domain", table_name="seo_sites")
+    op.drop_index("ix_seo_sites_business_id", table_name="seo_sites")
+    op.drop_table("seo_sites")

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -27,6 +27,8 @@ from app.repositories.auth_audit_repository import AuthAuditRepository
 from app.repositories.business_repository import BusinessRepository
 from app.repositories.lead_repository import LeadRepository
 from app.repositories.principal_repository import PrincipalRepository
+from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_site_repository import SEOSiteRepository
 from app.services.business_settings import BusinessSettingsService
 from app.services.api_credentials import APICredentialService
 from app.services.auth_audit import AuthAuditService
@@ -39,6 +41,7 @@ from app.services.parser import LeadParserService
 from app.services.principals import PrincipalService
 from app.services.reminder_engine import ReminderEngineService
 from app.services.response_metrics import ResponseMetricsService
+from app.services.seo_sites import SEOSiteService
 from app.services.summary import LeadSummaryService
 from app.services.timeline import LeadTimelineService
 
@@ -81,6 +84,14 @@ def get_auth_audit_repository(db: Session = Depends(get_db)) -> AuthAuditReposit
 
 def get_principal_repository(db: Session = Depends(get_db)) -> PrincipalRepository:
     return PrincipalRepository(db)
+
+
+def get_seo_site_repository(db: Session = Depends(get_db)) -> SEOSiteRepository:
+    return SEOSiteRepository(db)
+
+
+def get_seo_audit_repository(db: Session = Depends(get_db)) -> SEOAuditRepository:
+    return SEOAuditRepository(db)
 
 
 def get_parser_service() -> LeadParserService:
@@ -226,6 +237,18 @@ def get_business_settings_service(
     business_repository: BusinessRepository = Depends(get_business_repository),
 ) -> BusinessSettingsService:
     return BusinessSettingsService(session=db, business_repository=business_repository)
+
+
+def get_seo_site_service(
+    db: Session = Depends(get_db),
+    business_repository: BusinessRepository = Depends(get_business_repository),
+    seo_site_repository: SEOSiteRepository = Depends(get_seo_site_repository),
+) -> SEOSiteService:
+    return SEOSiteService(
+        session=db,
+        business_repository=business_repository,
+        seo_site_repository=seo_site_repository,
+    )
 
 
 def get_auth_audit_service(

--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -2,5 +2,6 @@ from app.api.routes.businesses import router as businesses_router
 from app.api.routes.intake import router as intake_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.leads import router as leads_router
+from app.api.routes.seo import router as seo_router
 
-__all__ = ["businesses_router", "intake_router", "jobs_router", "leads_router"]
+__all__ = ["businesses_router", "intake_router", "jobs_router", "leads_router", "seo_router"]

--- a/app/api/routes/seo.py
+++ b/app/api/routes/seo.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.deps import (
+    TenantContext,
+    get_seo_site_service,
+    get_tenant_context,
+    resolve_tenant_business_id,
+)
+from app.schemas.seo_site import (
+    SEOSiteCreateRequest,
+    SEOSiteListResponse,
+    SEOSiteRead,
+    SEOSiteUpdateRequest,
+)
+from app.services.seo_sites import SEOSiteNotFoundError, SEOSiteService, SEOSiteValidationError
+
+router = APIRouter(prefix="/api/businesses/{business_id}/seo", tags=["seo"])
+
+
+@router.get("/sites", response_model=SEOSiteListResponse)
+def list_seo_sites(
+    business_id: str,
+    tenant_context: TenantContext = Depends(get_tenant_context),
+    seo_site_service: SEOSiteService = Depends(get_seo_site_service),
+) -> SEOSiteListResponse:
+    scoped_business_id = resolve_tenant_business_id(
+        tenant_context=tenant_context,
+        requested_business_id=business_id,
+    )
+    try:
+        items = seo_site_service.list_sites(business_id=scoped_business_id)
+    except SEOSiteNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return SEOSiteListResponse(items=[SEOSiteRead.model_validate(site) for site in items], total=len(items))
+
+
+@router.post("/sites", response_model=SEOSiteRead, status_code=status.HTTP_201_CREATED)
+def create_seo_site(
+    business_id: str,
+    payload: SEOSiteCreateRequest,
+    tenant_context: TenantContext = Depends(get_tenant_context),
+    seo_site_service: SEOSiteService = Depends(get_seo_site_service),
+) -> SEOSiteRead:
+    scoped_business_id = resolve_tenant_business_id(
+        tenant_context=tenant_context,
+        requested_business_id=business_id,
+    )
+    try:
+        site = seo_site_service.create_site(business_id=scoped_business_id, payload=payload)
+    except SEOSiteNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except SEOSiteValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return SEOSiteRead.model_validate(site)
+
+
+@router.get("/sites/{site_id}", response_model=SEOSiteRead)
+def get_seo_site(
+    business_id: str,
+    site_id: str,
+    tenant_context: TenantContext = Depends(get_tenant_context),
+    seo_site_service: SEOSiteService = Depends(get_seo_site_service),
+) -> SEOSiteRead:
+    scoped_business_id = resolve_tenant_business_id(
+        tenant_context=tenant_context,
+        requested_business_id=business_id,
+    )
+    try:
+        site = seo_site_service.get_site(business_id=scoped_business_id, site_id=site_id)
+    except SEOSiteNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return SEOSiteRead.model_validate(site)
+
+
+@router.patch("/sites/{site_id}", response_model=SEOSiteRead)
+def patch_seo_site(
+    business_id: str,
+    site_id: str,
+    payload: SEOSiteUpdateRequest,
+    tenant_context: TenantContext = Depends(get_tenant_context),
+    seo_site_service: SEOSiteService = Depends(get_seo_site_service),
+) -> SEOSiteRead:
+    scoped_business_id = resolve_tenant_business_id(
+        tenant_context=tenant_context,
+        requested_business_id=business_id,
+    )
+    try:
+        site = seo_site_service.update_site(
+            business_id=scoped_business_id,
+            site_id=site_id,
+            payload=payload,
+        )
+    except SEOSiteNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except SEOSiteValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return SEOSiteRead.model_validate(site)

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.api.routes import businesses_router, intake_router, jobs_router, leads_router
+from app.api.routes import businesses_router, intake_router, jobs_router, leads_router, seo_router
 from app.core.config import get_settings
 from app.db.base import Base
 from app.db.session import SessionLocal, engine
@@ -38,3 +38,4 @@ app.include_router(intake_router)
 app.include_router(leads_router)
 app.include_router(jobs_router)
 app.include_router(businesses_router)
+app.include_router(seo_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,6 +4,10 @@ from app.models.business import Business
 from app.models.lead import Lead, LeadSource, LeadStatus
 from app.models.lead_event import ActorType, LeadEvent, LeadEventType
 from app.models.principal import Principal, PrincipalRole
+from app.models.seo_audit_finding import SEOAuditFinding
+from app.models.seo_audit_page import SEOAuditPage
+from app.models.seo_audit_run import SEOAuditRun, SEOAuditRunStatus
+from app.models.seo_site import SEOSite
 
 __all__ = [
     "APICredential",
@@ -17,4 +21,9 @@ __all__ = [
     "LeadStatus",
     "Principal",
     "PrincipalRole",
+    "SEOAuditFinding",
+    "SEOAuditPage",
+    "SEOAuditRun",
+    "SEOAuditRunStatus",
+    "SEOSite",
 ]

--- a/app/models/seo_audit_finding.py
+++ b/app/models/seo_audit_finding.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utc_now
+from app.db.base import Base
+
+
+class SEOAuditFinding(Base):
+    __tablename__ = "seo_audit_findings"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    business_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("businesses.id"),
+        nullable=False,
+        index=True,
+    )
+    site_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_sites.id"),
+        nullable=False,
+        index=True,
+    )
+    audit_run_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_audit_runs.id"),
+        nullable=False,
+        index=True,
+    )
+    page_id: Mapped[str | None] = mapped_column(
+        String(36),
+        ForeignKey("seo_audit_pages.id"),
+        nullable=True,
+        index=True,
+    )
+    finding_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    details: Mapped[str | None] = mapped_column(Text, nullable=True)
+    rule_key: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    suggested_fix: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    site = relationship("SEOSite")
+    audit_run = relationship("SEOAuditRun")
+    page = relationship("SEOAuditPage")

--- a/app/models/seo_audit_page.py
+++ b/app/models/seo_audit_page.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utc_now
+from app.db.base import Base
+
+
+class SEOAuditPage(Base):
+    __tablename__ = "seo_audit_pages"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    business_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("businesses.id"),
+        nullable=False,
+        index=True,
+    )
+    site_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_sites.id"),
+        nullable=False,
+        index=True,
+    )
+    audit_run_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_audit_runs.id"),
+        nullable=False,
+        index=True,
+    )
+    url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    title: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    meta_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    canonical_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    h1_json: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    h2_json: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    word_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    internal_link_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    image_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    missing_alt_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    fetched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    site = relationship("SEOSite")
+    audit_run = relationship("SEOAuditRun")

--- a/app/models/seo_audit_run.py
+++ b/app/models/seo_audit_run.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utc_now
+from app.db.base import Base
+
+
+class SEOAuditRunStatus(str, PyEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class SEOAuditRun(Base):
+    __tablename__ = "seo_audit_runs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    business_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("businesses.id"),
+        nullable=False,
+        index=True,
+    )
+    site_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_sites.id"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(String(32), default=SEOAuditRunStatus.QUEUED.value, nullable=False, index=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    max_pages: Mapped[int] = mapped_column(Integer, nullable=False, default=25)
+    max_depth: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
+    pages_discovered: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    pages_crawled: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    error_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_principal_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    site = relationship("SEOSite")

--- a/app/models/seo_site.py
+++ b/app/models/seo_site.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utc_now
+from app.db.base import Base
+
+
+class SEOSite(Base):
+    __tablename__ = "seo_sites"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    business_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("businesses.id"),
+        nullable=False,
+        index=True,
+    )
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    base_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    normalized_domain: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    industry: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    primary_location: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    service_areas_json: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_primary: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    business = relationship("Business")

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -3,6 +3,8 @@ from app.repositories.auth_audit_repository import AuthAuditRepository
 from app.repositories.business_repository import BusinessRepository
 from app.repositories.lead_repository import LeadRepository
 from app.repositories.principal_repository import PrincipalRepository
+from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_site_repository import SEOSiteRepository
 
 __all__ = [
     "APICredentialRepository",
@@ -10,4 +12,6 @@ __all__ = [
     "BusinessRepository",
     "LeadRepository",
     "PrincipalRepository",
+    "SEOAuditRepository",
+    "SEOSiteRepository",
 ]

--- a/app/repositories/seo_audit_repository.py
+++ b/app/repositories/seo_audit_repository.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from app.models.seo_audit_finding import SEOAuditFinding
+from app.models.seo_audit_page import SEOAuditPage
+from app.models.seo_audit_run import SEOAuditRun
+from app.models.seo_site import SEOSite
+
+
+class SEOAuditRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create_run(self, run: SEOAuditRun) -> SEOAuditRun:
+        site = self.session.scalar(
+            select(SEOSite.id).where(SEOSite.business_id == run.business_id).where(SEOSite.id == run.site_id)
+        )
+        if site is None:
+            raise ValueError("Site not found for business")
+
+        self.session.add(run)
+        self.session.flush()
+        return run
+
+    def get_run_for_business(self, business_id: str, run_id: str) -> SEOAuditRun | None:
+        stmt: Select[tuple[SEOAuditRun]] = (
+            select(SEOAuditRun).where(SEOAuditRun.business_id == business_id).where(SEOAuditRun.id == run_id)
+        )
+        return self.session.scalar(stmt)
+
+    def list_runs_for_business_site(self, business_id: str, site_id: str) -> list[SEOAuditRun]:
+        stmt: Select[tuple[SEOAuditRun]] = (
+            select(SEOAuditRun)
+            .where(SEOAuditRun.business_id == business_id)
+            .where(SEOAuditRun.site_id == site_id)
+            .order_by(SEOAuditRun.created_at.desc())
+        )
+        return list(self.session.scalars(stmt))
+
+    def add_page(self, page: SEOAuditPage) -> SEOAuditPage:
+        run = self.session.scalar(
+            select(SEOAuditRun).where(SEOAuditRun.id == page.audit_run_id)
+        )
+        if run is None:
+            raise ValueError("Audit run not found")
+        if run.business_id != page.business_id or run.site_id != page.site_id:
+            raise ValueError("Audit page scope mismatch")
+
+        self.session.add(page)
+        self.session.flush()
+        return page
+
+    def list_pages_for_business_run(self, business_id: str, run_id: str) -> list[SEOAuditPage]:
+        stmt: Select[tuple[SEOAuditPage]] = (
+            select(SEOAuditPage)
+            .where(SEOAuditPage.business_id == business_id)
+            .where(SEOAuditPage.audit_run_id == run_id)
+            .order_by(SEOAuditPage.url.asc())
+        )
+        return list(self.session.scalars(stmt))
+
+    def add_finding(self, finding: SEOAuditFinding) -> SEOAuditFinding:
+        run = self.session.scalar(
+            select(SEOAuditRun).where(SEOAuditRun.id == finding.audit_run_id)
+        )
+        if run is None:
+            raise ValueError("Audit run not found")
+        if run.business_id != finding.business_id or run.site_id != finding.site_id:
+            raise ValueError("Audit finding scope mismatch")
+
+        if finding.page_id is not None:
+            page = self.session.scalar(
+                select(SEOAuditPage).where(SEOAuditPage.id == finding.page_id)
+            )
+            if page is None:
+                raise ValueError("Audit page not found")
+            if page.audit_run_id != finding.audit_run_id or page.business_id != finding.business_id:
+                raise ValueError("Audit finding page scope mismatch")
+
+        self.session.add(finding)
+        self.session.flush()
+        return finding
+
+    def list_findings_for_business_run(self, business_id: str, run_id: str) -> list[SEOAuditFinding]:
+        stmt: Select[tuple[SEOAuditFinding]] = (
+            select(SEOAuditFinding)
+            .where(SEOAuditFinding.business_id == business_id)
+            .where(SEOAuditFinding.audit_run_id == run_id)
+            .order_by(SEOAuditFinding.created_at.asc(), SEOAuditFinding.id.asc())
+        )
+        return list(self.session.scalars(stmt))

--- a/app/repositories/seo_site_repository.py
+++ b/app/repositories/seo_site_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from app.models.seo_site import SEOSite
+
+
+class SEOSiteRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create(self, site: SEOSite) -> SEOSite:
+        self.session.add(site)
+        self.session.flush()
+        return site
+
+    def get_for_business(self, business_id: str, site_id: str) -> SEOSite | None:
+        stmt: Select[tuple[SEOSite]] = (
+            select(SEOSite).where(SEOSite.business_id == business_id).where(SEOSite.id == site_id)
+        )
+        return self.session.scalar(stmt)
+
+    def list_for_business(self, business_id: str) -> list[SEOSite]:
+        stmt: Select[tuple[SEOSite]] = (
+            select(SEOSite)
+            .where(SEOSite.business_id == business_id)
+            .order_by(SEOSite.is_primary.desc(), SEOSite.display_name.asc())
+        )
+        return list(self.session.scalars(stmt))
+
+    def clear_primary_for_business(self, business_id: str) -> None:
+        sites = self.list_for_business(business_id)
+        for site in sites:
+            if site.is_primary:
+                site.is_primary = False
+        self.session.flush()
+
+    def save(self, site: SEOSite) -> SEOSite:
+        self.session.add(site)
+        self.session.flush()
+        return site

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -13,6 +13,12 @@ from app.schemas.principal import (
     PrincipalRead,
     PrincipalUpdateRequest,
 )
+from app.schemas.seo_site import (
+    SEOSiteCreateRequest,
+    SEOSiteListResponse,
+    SEOSiteRead,
+    SEOSiteUpdateRequest,
+)
 from app.schemas.lead import (
     EmailIntakeRequest,
     EmailIntakeResponse,
@@ -61,5 +67,9 @@ __all__ = [
     "ReminderRunActionRead",
     "ReminderRunRequest",
     "ReminderRunResponse",
+    "SEOSiteCreateRequest",
+    "SEOSiteListResponse",
+    "SEOSiteRead",
+    "SEOSiteUpdateRequest",
     "StatusPatchResponse",
 ]

--- a/app/schemas/seo_site.py
+++ b/app/schemas/seo_site.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SEOSiteCreateRequest(BaseModel):
+    display_name: str = Field(min_length=1, max_length=255)
+    base_url: str = Field(min_length=1, max_length=2048)
+    industry: str | None = Field(default=None, max_length=128)
+    primary_location: str | None = Field(default=None, max_length=255)
+    service_areas: list[str] | None = None
+    is_active: bool = True
+    is_primary: bool = False
+
+
+class SEOSiteUpdateRequest(BaseModel):
+    display_name: str | None = Field(default=None, min_length=1, max_length=255)
+    base_url: str | None = Field(default=None, min_length=1, max_length=2048)
+    industry: str | None = Field(default=None, max_length=128)
+    primary_location: str | None = Field(default=None, max_length=255)
+    service_areas: list[str] | None = None
+    is_active: bool | None = None
+    is_primary: bool | None = None
+
+
+class SEOSiteRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    business_id: str
+    display_name: str
+    base_url: str
+    normalized_domain: str
+    industry: str | None
+    primary_location: str | None
+    service_areas_json: list[str] | None
+    is_active: bool
+    is_primary: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class SEOSiteListResponse(BaseModel):
+    items: list[SEOSiteRead]
+    total: int

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -15,6 +15,7 @@ from app.services.parser import LeadParserService
 from app.services.principals import PrincipalNotFoundError, PrincipalService, PrincipalValidationError
 from app.services.reminder_engine import ReminderEngineService
 from app.services.response_metrics import ResponseMetricsService
+from app.services.seo_sites import SEOSiteNotFoundError, SEOSiteService, SEOSiteValidationError
 from app.services.summary import LeadSummaryService
 from app.services.timeline import LeadTimelineService
 
@@ -35,6 +36,9 @@ __all__ = [
     "NotificationDispatchService",
     "ReminderEngineService",
     "ResponseMetricsService",
+    "SEOSiteNotFoundError",
+    "SEOSiteService",
+    "SEOSiteValidationError",
     "LeadSummaryService",
     "NotificationService",
     "PrincipalNotFoundError",

--- a/app/services/seo_sites.py
+++ b/app/services/seo_sites.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from app.models.seo_site import SEOSite
+from app.repositories.business_repository import BusinessRepository
+from app.repositories.seo_site_repository import SEOSiteRepository
+from app.schemas.seo_site import SEOSiteCreateRequest, SEOSiteUpdateRequest
+
+
+class SEOSiteNotFoundError(ValueError):
+    pass
+
+
+class SEOSiteValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class NormalizedURL:
+    url: str
+    domain: str
+
+
+class SEOSiteService:
+    def __init__(
+        self,
+        *,
+        session: Session,
+        business_repository: BusinessRepository,
+        seo_site_repository: SEOSiteRepository,
+    ) -> None:
+        self.session = session
+        self.business_repository = business_repository
+        self.seo_site_repository = seo_site_repository
+
+    def list_sites(self, *, business_id: str) -> list[SEOSite]:
+        self._require_business(business_id)
+        return self.seo_site_repository.list_for_business(business_id)
+
+    def get_site(self, *, business_id: str, site_id: str) -> SEOSite:
+        self._require_business(business_id)
+        site = self.seo_site_repository.get_for_business(business_id, site_id)
+        if site is None:
+            raise SEOSiteNotFoundError("SEO site not found")
+        return site
+
+    def create_site(self, *, business_id: str, payload: SEOSiteCreateRequest) -> SEOSite:
+        self._require_business(business_id)
+        normalized = self._normalize_base_url(payload.base_url)
+
+        existing_sites = self.seo_site_repository.list_for_business(business_id)
+        is_primary = payload.is_primary or len(existing_sites) == 0
+        if is_primary:
+            self.seo_site_repository.clear_primary_for_business(business_id)
+
+        site = SEOSite(
+            id=str(uuid4()),
+            business_id=business_id,
+            display_name=payload.display_name.strip(),
+            base_url=normalized.url,
+            normalized_domain=normalized.domain,
+            industry=self._clean_optional(payload.industry),
+            primary_location=self._clean_optional(payload.primary_location),
+            service_areas_json=payload.service_areas,
+            is_active=payload.is_active,
+            is_primary=is_primary,
+        )
+        self.seo_site_repository.create(site)
+        self.session.commit()
+        self.session.refresh(site)
+        return site
+
+    def update_site(
+        self,
+        *,
+        business_id: str,
+        site_id: str,
+        payload: SEOSiteUpdateRequest,
+    ) -> SEOSite:
+        self._require_business(business_id)
+        site = self.seo_site_repository.get_for_business(business_id, site_id)
+        if site is None:
+            raise SEOSiteNotFoundError("SEO site not found")
+
+        changes = payload.model_dump(exclude_unset=True)
+        if "display_name" in changes:
+            site.display_name = changes["display_name"].strip()
+        if "base_url" in changes:
+            normalized = self._normalize_base_url(changes["base_url"])
+            site.base_url = normalized.url
+            site.normalized_domain = normalized.domain
+        if "industry" in changes:
+            site.industry = self._clean_optional(changes["industry"])
+        if "primary_location" in changes:
+            site.primary_location = self._clean_optional(changes["primary_location"])
+        if "service_areas" in changes:
+            site.service_areas_json = changes["service_areas"]
+        if "is_active" in changes:
+            site.is_active = changes["is_active"]
+        if "is_primary" in changes:
+            if changes["is_primary"]:
+                self.seo_site_repository.clear_primary_for_business(business_id)
+                site.is_primary = True
+            else:
+                site.is_primary = False
+
+        self.seo_site_repository.save(site)
+        self.session.commit()
+        self.session.refresh(site)
+        return site
+
+    def _require_business(self, business_id: str) -> None:
+        business = self.business_repository.get(business_id)
+        if business is None:
+            raise SEOSiteNotFoundError("Business not found")
+
+    def _normalize_base_url(self, raw_base_url: str) -> NormalizedURL:
+        cleaned = raw_base_url.strip()
+        parsed = urlparse(cleaned)
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"}:
+            raise SEOSiteValidationError("base_url must use http or https")
+        if not parsed.netloc:
+            raise SEOSiteValidationError("base_url must include a valid domain")
+
+        domain = parsed.netloc.lower()
+        path = parsed.path or "/"
+        if path != "/":
+            path = path.rstrip("/")
+            if not path:
+                path = "/"
+
+        normalized = urlunparse((scheme, domain, path, "", "", ""))
+        return NormalizedURL(url=normalized, domain=domain)
+
+    @staticmethod
+    def _clean_optional(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -16,6 +16,10 @@ from app.models.auth_audit_event import AuthAuditEvent  # noqa: F401
 from app.models.business import Business
 from app.models.lead import Lead, LeadSource, LeadStatus
 from app.models.principal import Principal  # noqa: F401
+from app.models.seo_audit_finding import SEOAuditFinding  # noqa: F401
+from app.models.seo_audit_page import SEOAuditPage  # noqa: F401
+from app.models.seo_audit_run import SEOAuditRun  # noqa: F401
+from app.models.seo_site import SEOSite  # noqa: F401
 
 
 @pytest.fixture()

--- a/app/tests/test_seo_repositories.py
+++ b/app/tests/test_seo_repositories.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.models.business import Business
+from app.models.seo_audit_finding import SEOAuditFinding
+from app.models.seo_audit_page import SEOAuditPage
+from app.models.seo_audit_run import SEOAuditRun
+from app.models.seo_site import SEOSite
+from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_site_repository import SEOSiteRepository
+
+
+def test_seo_site_repository_business_scoping(db_session, seeded_business) -> None:
+    other_business = Business(
+        id=str(uuid4()),
+        name="Other Tenant",
+        notification_phone="+13035550199",
+        notification_email="owner@other.example",
+        sms_enabled=True,
+        email_enabled=True,
+        customer_auto_ack_enabled=True,
+        contractor_alerts_enabled=True,
+        timezone="America/Denver",
+    )
+    db_session.add(other_business)
+    db_session.flush()
+
+    site_repo = SEOSiteRepository(db_session)
+    site_a = site_repo.create(
+        SEOSite(
+            id=str(uuid4()),
+            business_id=seeded_business.id,
+            display_name="A",
+            base_url="https://a.example/",
+            normalized_domain="a.example",
+            is_active=True,
+            is_primary=True,
+        )
+    )
+    site_b = site_repo.create(
+        SEOSite(
+            id=str(uuid4()),
+            business_id=other_business.id,
+            display_name="B",
+            base_url="https://b.example/",
+            normalized_domain="b.example",
+            is_active=True,
+            is_primary=True,
+        )
+    )
+    db_session.commit()
+
+    assert site_repo.get_for_business(seeded_business.id, site_a.id) is not None
+    assert site_repo.get_for_business(seeded_business.id, site_b.id) is None
+    assert len(site_repo.list_for_business(seeded_business.id)) == 1
+
+
+def test_seo_audit_repository_scope_checks(db_session, seeded_business) -> None:
+    other_business = Business(
+        id=str(uuid4()),
+        name="Other Tenant",
+        notification_phone="+13035550199",
+        notification_email="owner@other.example",
+        sms_enabled=True,
+        email_enabled=True,
+        customer_auto_ack_enabled=True,
+        contractor_alerts_enabled=True,
+        timezone="America/Denver",
+    )
+    db_session.add(other_business)
+    db_session.flush()
+
+    site_repo = SEOSiteRepository(db_session)
+    audit_repo = SEOAuditRepository(db_session)
+    site_a = site_repo.create(
+        SEOSite(
+            id=str(uuid4()),
+            business_id=seeded_business.id,
+            display_name="A",
+            base_url="https://a.example/",
+            normalized_domain="a.example",
+            is_active=True,
+            is_primary=True,
+        )
+    )
+    site_b = site_repo.create(
+        SEOSite(
+            id=str(uuid4()),
+            business_id=other_business.id,
+            display_name="B",
+            base_url="https://b.example/",
+            normalized_domain="b.example",
+            is_active=True,
+            is_primary=True,
+        )
+    )
+    db_session.flush()
+
+    run = audit_repo.create_run(
+        SEOAuditRun(
+            id=str(uuid4()),
+            business_id=seeded_business.id,
+            site_id=site_a.id,
+            status="queued",
+            max_pages=10,
+            max_depth=2,
+        )
+    )
+    db_session.flush()
+
+    page = audit_repo.add_page(
+        SEOAuditPage(
+            id=str(uuid4()),
+            business_id=seeded_business.id,
+            site_id=site_a.id,
+            audit_run_id=run.id,
+            url="https://a.example/",
+        )
+    )
+    audit_repo.add_finding(
+        SEOAuditFinding(
+            id=str(uuid4()),
+            business_id=seeded_business.id,
+            site_id=site_a.id,
+            audit_run_id=run.id,
+            page_id=page.id,
+            finding_type="missing_title",
+            category="metadata",
+            severity="high",
+            title="Missing title",
+            details="No title tag",
+            rule_key="missing_title",
+        )
+    )
+    db_session.commit()
+
+    assert audit_repo.get_run_for_business(seeded_business.id, run.id) is not None
+    assert audit_repo.get_run_for_business(other_business.id, run.id) is None
+    assert len(audit_repo.list_findings_for_business_run(seeded_business.id, run.id)) == 1
+    assert len(audit_repo.list_findings_for_business_run(other_business.id, run.id)) == 0
+
+    with pytest.raises(ValueError):
+        audit_repo.add_page(
+            SEOAuditPage(
+                id=str(uuid4()),
+                business_id=other_business.id,
+                site_id=site_b.id,
+                audit_run_id=run.id,
+                url="https://b.example/",
+            )
+        )

--- a/app/tests/test_seo_sites_api.py
+++ b/app/tests/test_seo_sites_api.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import TenantContext, get_db, get_tenant_context
+from app.api.routes.seo import router as seo_router
+from app.models.business import Business
+
+
+def _override_tenant_context(business_id: str):
+    def _resolver() -> TenantContext:
+        return TenantContext(
+            business_id=business_id,
+            principal_id=f"test-principal:{business_id}",
+            auth_source="test",
+        )
+
+    return _resolver
+
+
+def _make_client(db_session, *, business_id: str) -> TestClient:
+    app = FastAPI()
+    app.include_router(seo_router)
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_tenant_context] = _override_tenant_context(business_id)
+    return TestClient(app)
+
+
+def test_seo_site_crud_and_business_scoping(db_session, seeded_business) -> None:
+    other_business = Business(
+        id=str(uuid4()),
+        name="Other Tenant",
+        notification_phone="+13035550199",
+        notification_email="owner@other.example",
+        sms_enabled=True,
+        email_enabled=True,
+        customer_auto_ack_enabled=True,
+        contractor_alerts_enabled=True,
+        timezone="America/Denver",
+    )
+    db_session.add(other_business)
+    db_session.commit()
+
+    client = _make_client(db_session, business_id=seeded_business.id)
+
+    create_response = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites",
+        json={
+            "display_name": "Main Site",
+            "base_url": "https://Example.COM/",
+            "industry": "Fire Restoration",
+            "primary_location": "Denver, CO",
+            "service_areas": ["Denver", "Lakewood"],
+            "is_active": True,
+            "is_primary": True,
+        },
+    )
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert created["normalized_domain"] == "example.com"
+    assert created["base_url"] == "https://example.com/"
+
+    site_id = created["id"]
+    list_response = client.get(f"/api/businesses/{seeded_business.id}/seo/sites")
+    assert list_response.status_code == 200
+    payload = list_response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["id"] == site_id
+
+    read_response = client.get(f"/api/businesses/{seeded_business.id}/seo/sites/{site_id}")
+    assert read_response.status_code == 200
+
+    patch_response = client.patch(
+        f"/api/businesses/{seeded_business.id}/seo/sites/{site_id}",
+        json={"display_name": "Main Site Updated", "base_url": "https://example.com/services/"},
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched["display_name"] == "Main Site Updated"
+    assert patched["base_url"] == "https://example.com/services"
+
+    cross_tenant = client.get(f"/api/businesses/{other_business.id}/seo/sites/{site_id}")
+    assert cross_tenant.status_code == 404
+
+
+def test_seo_site_invalid_url_rejected(db_session, seeded_business) -> None:
+    client = _make_client(db_session, business_id=seeded_business.id)
+    response = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites",
+        json={
+            "display_name": "Bad URL Site",
+            "base_url": "ftp://example.com",
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
Implements #19.\n\nScope delivered:\n- Added Phase 1 SEO data foundations: seo_sites, seo_audit_runs, seo_audit_pages, seo_audit_findings\n- Added Alembic migration 0011 for those tables\n- Added business-scoped repositories for sites and audits\n- Added SEO site CRUD service + routes\n- Added tests for site CRUD, business isolation, and repository-level scoping\n\nOut of scope intentionally not implemented:\n- Crawl execution\n- Deterministic finding generation\n- AI summaries\n- Competitor/report features\n\nValidation:\n- pytest -q (89 passed)\n- targeted SEO tests passed