### PR TITLE
Issue #21: manual AI audit summary integration with versioned history

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -27,6 +27,7 @@ from app.models import (
     seo_audit_finding,
     seo_audit_page,
     seo_audit_run,
+    seo_audit_summary,
     seo_site,
 )
 

--- a/alembic/versions/0012_seo_audit_summaries.py
+++ b/alembic/versions/0012_seo_audit_summaries.py
@@ -1,0 +1,70 @@
+"""add seo audit summaries for phase 1 manual ai summarization
+
+Revision ID: 0012_seo_audit_summaries
+Revises: 0011_seo_phase1_foundations
+Create Date: 2026-03-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0012_seo_audit_summaries"
+down_revision = "0011_seo_phase1_foundations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "seo_audit_summaries",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("business_id", sa.String(length=36), nullable=False),
+        sa.Column("site_id", sa.String(length=36), nullable=False),
+        sa.Column("audit_run_id", sa.String(length=36), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="completed"),
+        sa.Column("overall_health_summary", sa.Text(), nullable=True),
+        sa.Column("top_issues_json", sa.JSON(), nullable=True),
+        sa.Column("top_priorities_json", sa.JSON(), nullable=True),
+        sa.Column("plain_english_explanation", sa.Text(), nullable=True),
+        sa.Column("model_name", sa.String(length=128), nullable=False),
+        sa.Column("prompt_version", sa.String(length=64), nullable=False),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column("created_by_principal_id", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["business_id"], ["businesses.id"]),
+        sa.ForeignKeyConstraint(["site_id"], ["seo_sites.id"]),
+        sa.ForeignKeyConstraint(["audit_run_id"], ["seo_audit_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_seo_audit_summaries_business_id", "seo_audit_summaries", ["business_id"], unique=False)
+    op.create_index("ix_seo_audit_summaries_site_id", "seo_audit_summaries", ["site_id"], unique=False)
+    op.create_index("ix_seo_audit_summaries_audit_run_id", "seo_audit_summaries", ["audit_run_id"], unique=False)
+    op.create_index(
+        "ix_seo_audit_summaries_business_run_version",
+        "seo_audit_summaries",
+        ["business_id", "audit_run_id", "version"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_seo_audit_summaries_business_run_version", table_name="seo_audit_summaries")
+    op.drop_index("ix_seo_audit_summaries_audit_run_id", table_name="seo_audit_summaries")
+    op.drop_index("ix_seo_audit_summaries_site_id", table_name="seo_audit_summaries")
+    op.drop_index("ix_seo_audit_summaries_business_id", table_name="seo_audit_summaries")
+    op.drop_table("seo_audit_summaries")

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -14,8 +14,10 @@ from app.integrations import (
     DevEmailProvider,
     DevSMSProvider,
     EmailProvider,
+    MockSEOAuditSummaryProvider,
     MockEmailProvider,
     MockSMSProvider,
+    SEOAuditSummaryProvider,
     SMTPEmailProvider,
     SMSProvider,
     TwilioSMSProvider,
@@ -28,6 +30,7 @@ from app.repositories.business_repository import BusinessRepository
 from app.repositories.lead_repository import LeadRepository
 from app.repositories.principal_repository import PrincipalRepository
 from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_audit_summary_repository import SEOAuditSummaryRepository
 from app.repositories.seo_site_repository import SEOSiteRepository
 from app.services.business_settings import BusinessSettingsService
 from app.services.api_credentials import APICredentialService
@@ -46,6 +49,7 @@ from app.services.seo_crawler import SEOCrawler
 from app.services.seo_extractor import SEOExtractor
 from app.services.seo_finding_rules import SEOFindingRules
 from app.services.seo_sites import SEOSiteService
+from app.services.seo_summary import SEOSummaryService
 from app.services.summary import LeadSummaryService
 from app.services.timeline import LeadTimelineService
 
@@ -96,6 +100,10 @@ def get_seo_site_repository(db: Session = Depends(get_db)) -> SEOSiteRepository:
 
 def get_seo_audit_repository(db: Session = Depends(get_db)) -> SEOAuditRepository:
     return SEOAuditRepository(db)
+
+
+def get_seo_audit_summary_repository(db: Session = Depends(get_db)) -> SEOAuditSummaryRepository:
+    return SEOAuditSummaryRepository(db)
 
 
 def get_parser_service() -> LeadParserService:
@@ -284,6 +292,26 @@ def get_seo_audit_service(
         crawler=crawler,
         extractor=extractor,
         finding_rules=finding_rules,
+    )
+
+
+def get_seo_summary_provider() -> SEOAuditSummaryProvider:
+    return MockSEOAuditSummaryProvider()
+
+
+def get_seo_summary_service(
+    db: Session = Depends(get_db),
+    business_repository: BusinessRepository = Depends(get_business_repository),
+    seo_audit_repository: SEOAuditRepository = Depends(get_seo_audit_repository),
+    seo_audit_summary_repository: SEOAuditSummaryRepository = Depends(get_seo_audit_summary_repository),
+    provider: SEOAuditSummaryProvider = Depends(get_seo_summary_provider),
+) -> SEOSummaryService:
+    return SEOSummaryService(
+        session=db,
+        business_repository=business_repository,
+        seo_audit_repository=seo_audit_repository,
+        seo_audit_summary_repository=seo_audit_summary_repository,
+        provider=provider,
     )
 
 

--- a/app/api/routes/seo.py
+++ b/app/api/routes/seo.py
@@ -6,6 +6,7 @@ from app.api.deps import (
     TenantContext,
     get_seo_audit_service,
     get_seo_site_service,
+    get_seo_summary_service,
     get_tenant_context,
     resolve_tenant_business_id,
 )
@@ -24,6 +25,8 @@ from app.schemas.seo_site import (
 )
 from app.services.seo_audit import SEOAuditNotFoundError, SEOAuditService, SEOAuditValidationError
 from app.services.seo_sites import SEOSiteNotFoundError, SEOSiteService, SEOSiteValidationError
+from app.services.seo_summary import SEOSummaryNotFoundError, SEOSummaryService, SEOSummaryValidationError
+from app.schemas.seo_summary import SEOAuditSummaryRead
 
 router = APIRouter(prefix="/api/businesses/{business_id}/seo", tags=["seo"])
 
@@ -192,3 +195,27 @@ def list_seo_audit_run_findings(
         items=[SEOAuditFindingRead.model_validate(item) for item in findings],
         total=len(findings),
     )
+
+
+@router.post("/audit-runs/{run_id}/summarize", response_model=SEOAuditSummaryRead, status_code=status.HTTP_201_CREATED)
+def summarize_seo_audit_run(
+    business_id: str,
+    run_id: str,
+    tenant_context: TenantContext = Depends(get_tenant_context),
+    seo_summary_service: SEOSummaryService = Depends(get_seo_summary_service),
+) -> SEOAuditSummaryRead:
+    scoped_business_id = resolve_tenant_business_id(
+        tenant_context=tenant_context,
+        requested_business_id=business_id,
+    )
+    try:
+        result = seo_summary_service.summarize_run(
+            business_id=scoped_business_id,
+            run_id=run_id,
+            created_by_principal_id=tenant_context.principal_id,
+        )
+    except SEOSummaryNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except SEOSummaryValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return SEOAuditSummaryRead.model_validate(result.summary)

--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -12,6 +12,11 @@ from app.integrations.sms_provider import (
     SMSProvider,
     TwilioSMSProvider,
 )
+from app.integrations.seo_summary_provider import (
+    MockSEOAuditSummaryProvider,
+    SEOAuditSummaryOutput,
+    SEOAuditSummaryProvider,
+)
 
 __all__ = [
     "DevEmailProvider",
@@ -23,5 +28,8 @@ __all__ = [
     "SMTPEmailProvider",
     "SMSDispatchResult",
     "SMSProvider",
+    "MockSEOAuditSummaryProvider",
+    "SEOAuditSummaryOutput",
+    "SEOAuditSummaryProvider",
     "TwilioSMSProvider",
 ]

--- a/app/integrations/seo_summary_provider.py
+++ b/app/integrations/seo_summary_provider.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.models.seo_audit_finding import SEOAuditFinding
+from app.models.seo_audit_run import SEOAuditRun
+
+
+@dataclass(frozen=True)
+class SEOAuditSummaryOutput:
+    overall_health_summary: str
+    top_issues: list[str]
+    top_priorities: list[str]
+    plain_english_explanation: str
+    model_name: str
+    prompt_version: str
+
+
+class SEOAuditSummaryProvider(Protocol):
+    def generate_summary(self, *, run: SEOAuditRun, findings: list[SEOAuditFinding]) -> SEOAuditSummaryOutput:
+        ...
+
+
+class MockSEOAuditSummaryProvider:
+    def __init__(self, *, model_name: str = "mock-seo-summary-v1", prompt_version: str = "seo-summary-v1") -> None:
+        self.model_name = model_name
+        self.prompt_version = prompt_version
+
+    def generate_summary(self, *, run: SEOAuditRun, findings: list[SEOAuditFinding]) -> SEOAuditSummaryOutput:
+        by_severity: dict[str, int] = {}
+        by_type: dict[str, int] = {}
+        for finding in findings:
+            by_severity[finding.severity] = by_severity.get(finding.severity, 0) + 1
+            by_type[finding.finding_type] = by_type.get(finding.finding_type, 0) + 1
+
+        severity_summary = ", ".join(f"{k}:{v}" for k, v in sorted(by_severity.items()))
+        overall = (
+            f"Audit run {run.id} scanned {run.pages_crawled} pages and found {len(findings)} issues. "
+            f"Severity mix: {severity_summary or 'none'}."
+        )
+        ranked_types = sorted(by_type.items(), key=lambda item: item[1], reverse=True)
+        top_issues = [f"{item[0]} ({item[1]})" for item in ranked_types[:3]]
+        top_priorities = [
+            "Fix high-severity metadata and technical issues first.",
+            "Address missing titles/meta descriptions on key pages.",
+            "Resolve thin content and broken internal links on service pages.",
+        ]
+        plain_english = (
+            "Your site has clear SEO gaps that can be fixed in a prioritized order. "
+            "Start with technical and metadata blockers, then improve page depth."
+        )
+        return SEOAuditSummaryOutput(
+            overall_health_summary=overall,
+            top_issues=top_issues,
+            top_priorities=top_priorities,
+            plain_english_explanation=plain_english,
+            model_name=self.model_name,
+            prompt_version=self.prompt_version,
+        )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.principal import Principal, PrincipalRole
 from app.models.seo_audit_finding import SEOAuditFinding
 from app.models.seo_audit_page import SEOAuditPage
 from app.models.seo_audit_run import SEOAuditRun, SEOAuditRunStatus
+from app.models.seo_audit_summary import SEOAuditSummary
 from app.models.seo_site import SEOSite
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     "SEOAuditPage",
     "SEOAuditRun",
     "SEOAuditRunStatus",
+    "SEOAuditSummary",
     "SEOSite",
 ]

--- a/app/models/seo_audit_summary.py
+++ b/app/models/seo_audit_summary.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utc_now
+from app.db.base import Base
+
+
+class SEOAuditSummary(Base):
+    __tablename__ = "seo_audit_summaries"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    business_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("businesses.id"),
+        nullable=False,
+        index=True,
+    )
+    site_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_sites.id"),
+        nullable=False,
+        index=True,
+    )
+    audit_run_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("seo_audit_runs.id"),
+        nullable=False,
+        index=True,
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="completed")
+    overall_health_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    top_issues_json: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    top_priorities_json: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    plain_english_explanation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    error_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_principal_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    audit_run = relationship("SEOAuditRun")

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -4,6 +4,7 @@ from app.repositories.business_repository import BusinessRepository
 from app.repositories.lead_repository import LeadRepository
 from app.repositories.principal_repository import PrincipalRepository
 from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_audit_summary_repository import SEOAuditSummaryRepository
 from app.repositories.seo_site_repository import SEOSiteRepository
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "LeadRepository",
     "PrincipalRepository",
     "SEOAuditRepository",
+    "SEOAuditSummaryRepository",
     "SEOSiteRepository",
 ]

--- a/app/repositories/seo_audit_summary_repository.py
+++ b/app/repositories/seo_audit_summary_repository.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.seo_audit_summary import SEOAuditSummary
+
+
+class SEOAuditSummaryRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create(self, summary: SEOAuditSummary) -> SEOAuditSummary:
+        self.session.add(summary)
+        self.session.flush()
+        return summary
+
+    def list_for_business_run(self, business_id: str, run_id: str) -> list[SEOAuditSummary]:
+        stmt: Select[tuple[SEOAuditSummary]] = (
+            select(SEOAuditSummary)
+            .where(SEOAuditSummary.business_id == business_id)
+            .where(SEOAuditSummary.audit_run_id == run_id)
+            .order_by(SEOAuditSummary.version.asc(), SEOAuditSummary.created_at.asc())
+        )
+        return list(self.session.scalars(stmt))
+
+    def next_version(self, business_id: str, run_id: str) -> int:
+        stmt = (
+            select(func.max(SEOAuditSummary.version))
+            .where(SEOAuditSummary.business_id == business_id)
+            .where(SEOAuditSummary.audit_run_id == run_id)
+        )
+        max_version = self.session.scalar(stmt)
+        return int(max_version or 0) + 1

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -26,6 +26,7 @@ from app.schemas.seo_audit import (
     SEOAuditRunListResponse,
     SEOAuditRunRead,
 )
+from app.schemas.seo_summary import SEOAuditSummaryRead
 from app.schemas.lead import (
     EmailIntakeRequest,
     EmailIntakeResponse,
@@ -83,5 +84,6 @@ __all__ = [
     "SEOAuditRunCreateRequest",
     "SEOAuditRunListResponse",
     "SEOAuditRunRead",
+    "SEOAuditSummaryRead",
     "StatusPatchResponse",
 ]

--- a/app/schemas/seo_summary.py
+++ b/app/schemas/seo_summary.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SEOAuditSummaryRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    business_id: str
+    site_id: str
+    audit_run_id: str
+    version: int
+    status: str
+    overall_health_summary: str | None
+    top_issues_json: list[str] | None
+    top_priorities_json: list[str] | None
+    plain_english_explanation: str | None
+    model_name: str
+    prompt_version: str
+    error_summary: str | None
+    created_by_principal_id: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -20,6 +20,7 @@ from app.services.seo_crawler import SEOCrawler, SEOCrawlerValidationError
 from app.services.seo_extractor import SEOExtractor
 from app.services.seo_finding_rules import SEOFindingRules
 from app.services.seo_sites import SEOSiteNotFoundError, SEOSiteService, SEOSiteValidationError
+from app.services.seo_summary import SEOSummaryNotFoundError, SEOSummaryService, SEOSummaryValidationError
 from app.services.summary import LeadSummaryService
 from app.services.timeline import LeadTimelineService
 
@@ -50,6 +51,9 @@ __all__ = [
     "SEOSiteNotFoundError",
     "SEOSiteService",
     "SEOSiteValidationError",
+    "SEOSummaryNotFoundError",
+    "SEOSummaryService",
+    "SEOSummaryValidationError",
     "LeadSummaryService",
     "NotificationService",
     "PrincipalNotFoundError",

--- a/app/services/seo_summary.py
+++ b/app/services/seo_summary.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.integrations.seo_summary_provider import SEOAuditSummaryProvider
+from app.models.seo_audit_summary import SEOAuditSummary
+from app.repositories.business_repository import BusinessRepository
+from app.repositories.seo_audit_repository import SEOAuditRepository
+from app.repositories.seo_audit_summary_repository import SEOAuditSummaryRepository
+
+
+logger = logging.getLogger(__name__)
+
+
+class SEOSummaryNotFoundError(ValueError):
+    pass
+
+
+class SEOSummaryValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class SEOSummaryResult:
+    summary: SEOAuditSummary
+
+
+class SEOSummaryService:
+    def __init__(
+        self,
+        *,
+        session: Session,
+        business_repository: BusinessRepository,
+        seo_audit_repository: SEOAuditRepository,
+        seo_audit_summary_repository: SEOAuditSummaryRepository,
+        provider: SEOAuditSummaryProvider,
+    ) -> None:
+        self.session = session
+        self.business_repository = business_repository
+        self.seo_audit_repository = seo_audit_repository
+        self.seo_audit_summary_repository = seo_audit_summary_repository
+        self.provider = provider
+
+    def summarize_run(
+        self,
+        *,
+        business_id: str,
+        run_id: str,
+        created_by_principal_id: str | None,
+    ) -> SEOSummaryResult:
+        business = self.business_repository.get(business_id)
+        if business is None:
+            raise SEOSummaryNotFoundError("Business not found")
+
+        run = self.seo_audit_repository.get_run_for_business(business_id, run_id)
+        if run is None:
+            raise SEOSummaryNotFoundError("SEO audit run not found")
+        if run.status != "completed":
+            raise SEOSummaryValidationError("SEO audit run must be completed before summarization")
+
+        findings = self.seo_audit_repository.list_findings_for_business_run(business_id, run_id)
+        version = self.seo_audit_summary_repository.next_version(business_id, run_id)
+
+        try:
+            output = self.provider.generate_summary(run=run, findings=findings)
+            summary = SEOAuditSummary(
+                id=str(uuid4()),
+                business_id=business_id,
+                site_id=run.site_id,
+                audit_run_id=run.id,
+                version=version,
+                status="completed",
+                overall_health_summary=output.overall_health_summary,
+                top_issues_json=output.top_issues,
+                top_priorities_json=output.top_priorities,
+                plain_english_explanation=output.plain_english_explanation,
+                model_name=output.model_name,
+                prompt_version=output.prompt_version,
+                error_summary=None,
+                created_by_principal_id=created_by_principal_id,
+            )
+            self.seo_audit_summary_repository.create(summary)
+            self.session.commit()
+            self.session.refresh(summary)
+            return SEOSummaryResult(summary=summary)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "SEO summary generation failed business_id=%s audit_run_id=%s reason=%s",
+                business_id,
+                run_id,
+                str(exc),
+            )
+            failed = SEOAuditSummary(
+                id=str(uuid4()),
+                business_id=business_id,
+                site_id=run.site_id,
+                audit_run_id=run.id,
+                version=version,
+                status="failed",
+                overall_health_summary=None,
+                top_issues_json=[],
+                top_priorities_json=[],
+                plain_english_explanation=None,
+                model_name="summary-provider-error",
+                prompt_version="seo-summary-v1",
+                error_summary=str(exc),
+                created_by_principal_id=created_by_principal_id,
+            )
+            self.seo_audit_summary_repository.create(failed)
+            self.session.commit()
+            raise SEOSummaryValidationError("Summary generation failed") from exc

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -19,6 +19,7 @@ from app.models.principal import Principal  # noqa: F401
 from app.models.seo_audit_finding import SEOAuditFinding  # noqa: F401
 from app.models.seo_audit_page import SEOAuditPage  # noqa: F401
 from app.models.seo_audit_run import SEOAuditRun  # noqa: F401
+from app.models.seo_audit_summary import SEOAuditSummary  # noqa: F401
 from app.models.seo_site import SEOSite  # noqa: F401
 
 

--- a/app/tests/test_seo_summary_api.py
+++ b/app/tests/test_seo_summary_api.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import (
+    TenantContext,
+    get_db,
+    get_seo_crawler,
+    get_seo_summary_provider,
+    get_tenant_context,
+)
+from app.api.routes.seo import router as seo_router
+from app.integrations.seo_summary_provider import SEOAuditSummaryProvider
+from app.models.seo_audit_run import SEOAuditRun
+from app.models.seo_audit_summary import SEOAuditSummary
+from app.services.seo_crawler import FetchResponse, SEOCrawler
+
+
+class _FakeCrawler(SEOCrawler):
+    def __init__(self, pages: dict[str, FetchResponse]) -> None:
+        super().__init__(timeout_seconds=1)
+        self.pages = pages
+
+    def _fetch(self, url: str) -> FetchResponse:  # type: ignore[override]
+        return self.pages[url]
+
+
+class _FailingSummaryProvider:
+    def generate_summary(self, *, run, findings):  # noqa: ANN001, ANN202
+        raise RuntimeError("provider unavailable")
+
+
+def _override_tenant_context(business_id: str):
+    def _resolver() -> TenantContext:
+        return TenantContext(
+            business_id=business_id,
+            principal_id=f"test-principal:{business_id}",
+            auth_source="test",
+        )
+
+    return _resolver
+
+
+def _make_client(db_session, *, business_id: str, summary_provider: SEOAuditSummaryProvider | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(seo_router)
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    fake_crawler = _FakeCrawler(
+        pages={
+            "https://example.com/": FetchResponse(
+                final_url="https://example.com/",
+                status_code=200,
+                body='<html><body><a href="/service">service</a></body></html>',
+            ),
+            "https://example.com/service": FetchResponse(
+                final_url="https://example.com/service",
+                status_code=200,
+                body="<html><body>service page</body></html>",
+            ),
+        }
+    )
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_tenant_context] = _override_tenant_context(business_id)
+    app.dependency_overrides[get_seo_crawler] = lambda: fake_crawler
+    if summary_provider is not None:
+        app.dependency_overrides[get_seo_summary_provider] = lambda: summary_provider
+    return TestClient(app)
+
+
+def test_summary_generation_is_manual_trigger_and_versioned(db_session, seeded_business) -> None:
+    client = _make_client(db_session, business_id=seeded_business.id)
+    create_site = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites",
+        json={"display_name": "Main", "base_url": "https://example.com/"},
+    )
+    assert create_site.status_code == 201
+    site_id = create_site.json()["id"]
+
+    run_response = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites/{site_id}/audit-runs",
+        json={"max_pages": 10, "max_depth": 2},
+    )
+    assert run_response.status_code == 201
+    run_id = run_response.json()["id"]
+
+    # Manual-trigger only: no summaries should exist until summarize endpoint is called.
+    assert db_session.query(SEOAuditSummary).count() == 0
+
+    first_summary = client.post(f"/api/businesses/{seeded_business.id}/seo/audit-runs/{run_id}/summarize")
+    assert first_summary.status_code == 201
+    payload = first_summary.json()
+    assert payload["status"] == "completed"
+    assert payload["version"] == 1
+    assert isinstance(payload["overall_health_summary"], str)
+    assert isinstance(payload["top_issues_json"], list)
+    assert isinstance(payload["top_priorities_json"], list)
+    assert isinstance(payload["plain_english_explanation"], str)
+
+    second_summary = client.post(f"/api/businesses/{seeded_business.id}/seo/audit-runs/{run_id}/summarize")
+    assert second_summary.status_code == 201
+    assert second_summary.json()["version"] == 2
+
+
+def test_summary_failure_does_not_change_completed_run_state(db_session, seeded_business) -> None:
+    client = _make_client(
+        db_session,
+        business_id=seeded_business.id,
+        summary_provider=_FailingSummaryProvider(),
+    )
+    create_site = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites",
+        json={"display_name": "Main", "base_url": "https://example.com/"},
+    )
+    assert create_site.status_code == 201
+    site_id = create_site.json()["id"]
+
+    run_response = client.post(
+        f"/api/businesses/{seeded_business.id}/seo/sites/{site_id}/audit-runs",
+        json={"max_pages": 10, "max_depth": 2},
+    )
+    assert run_response.status_code == 201
+    run_id = run_response.json()["id"]
+    assert run_response.json()["status"] == "completed"
+
+    summarize = client.post(f"/api/businesses/{seeded_business.id}/seo/audit-runs/{run_id}/summarize")
+    assert summarize.status_code == 422
+
+    run_after = client.get(f"/api/businesses/{seeded_business.id}/seo/audit-runs/{run_id}")
+    assert run_after.status_code == 200
+    assert run_after.json()["status"] == "completed"
+
+    failed_summary = db_session.query(SEOAuditSummary).filter(SEOAuditSummary.audit_run_id == run_id).one()
+    assert failed_summary.status == "failed"
+
+
+def test_summary_requires_completed_run(db_session, seeded_business) -> None:
+    run = SEOAuditRun(
+        id=str(uuid4()),
+        business_id=seeded_business.id,
+        site_id=str(uuid4()),
+        status="queued",
+        max_pages=10,
+        max_depth=2,
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    client = _make_client(db_session, business_id=seeded_business.id)
+    response = client.post(f"/api/businesses/{seeded_business.id}/seo/audit-runs/{run.id}/summarize")
+    assert response.status_code == 422


### PR DESCRIPTION
Implements #21 as PR3 (stacked on #25 / issues #19-#20).\n\nScope delivered:\n- Added seo_audit_summaries persistence model + migration (0012)\n- Added summary repository and service lifecycle\n- Added AI summary provider abstraction boundary (mock provider)\n- Added manual summarize endpoint: POST /api/businesses/{business_id}/seo/audit-runs/{run_id}/summarize\n- Summary generation grounded on stored deterministic findings from completed runs\n- Regeneration creates versioned summary history\n- Failure isolation: provider failure persists failed summary attempt and does not invalidate completed run\n\nOut of scope intentionally not implemented:\n- Content briefs/page drafting/metadata generation\n- Recommendation engine\n- New crawl rules\n\nValidation:\n- pytest -q (95 passed)